### PR TITLE
Fix background tint size

### DIFF
--- a/scenes/game/batter-card-zoomed-overlay.lua
+++ b/scenes/game/batter-card-zoomed-overlay.lua
@@ -44,10 +44,10 @@ function scene:show(event)
           widget.newButton(
           {
             shape = "rect",
-            width = display.actualContentWidth,
-            height = display.actualContentHeight,
+            width = display.contentWidth,
+            height = display.actualContentHeight + 100,
             left = 0,
-            top = 0,
+            top = -100,
             onRelease = onBackgroundClick
           }
         )

--- a/scenes/game/batter-card-zoomed-overlay.lua
+++ b/scenes/game/batter-card-zoomed-overlay.lua
@@ -44,7 +44,7 @@ function scene:show(event)
           widget.newButton(
           {
             shape = "rect",
-            width = display.contentWidth,
+            width = display.actualContentWidth,
             height = display.actualContentHeight + 100,
             left = 0,
             top = -100,


### PR DESCRIPTION
Fix background for squarer aspect ratio devices.

<img width="772" alt="Screen Shot 2021-01-31 at 11 50 35 AM" src="https://user-images.githubusercontent.com/3794516/106396062-887ea480-63ba-11eb-814c-6ce461219273.png">
<img width="1597" alt="Screen Shot 2021-01-31 at 11 50 52 AM" src="https://user-images.githubusercontent.com/3794516/106396071-92a0a300-63ba-11eb-864f-f0602b73318c.png">
