### PR TITLE
Add websocket, refactor internal datastore

### DIFF
--- a/build.settings
+++ b/build.settings
@@ -42,7 +42,10 @@ settings =
 	--
 	plugins =
 	{
-
+		["plugin.solarwebsockets"] =
+		{
+			publisherId = "io.joehinkle",
+		},
 	},
 
 	--

--- a/scenes/game/batter-athlete-selection-scene.lua
+++ b/scenes/game/batter-athlete-selection-scene.lua
@@ -92,8 +92,8 @@ scene:addEventListener("destroy", scene)
 
 -- Action for when the player confirms and locks in a batter athlete card
 function onConfirmBatterCard()
-  batterManager:getResolverManager():setBatter(selectedBatterCard)
-  print(batterManager:getResolverManager():getBatter():getName())
+  batterManager:getDataStore():setBatter(selectedBatterCard)
+  print(batterManager:getDataStore():getBatter():getName())
   composer.gotoScene("scenes.game.batter-strike-zone-creation-scene")
 end
 
@@ -142,7 +142,7 @@ end
 -- Display the available athletes options to be the batter
 -- Grab the available batters to be selected
 function renderBatterCardSelection()
-  local availableBatters = batterManager:getAvailableBatters()
+  local availableBatters = batterManager:getDataStore():getAvailableBatters()
   for i, batter in ipairs(availableBatters) do
     -- Create the batter card UI
     viewManager:addComponent(
@@ -160,7 +160,6 @@ function renderBatterCardSelection()
             end
           }
         )
-        print(display.contentWidth)
         batterImg.x = (display.contentWidth / (#availableBatters + 1) * i)
         batterImg.y = display.contentCenterY + 20
         return batterImg

--- a/scenes/game/batter-result-scene.lua
+++ b/scenes/game/batter-result-scene.lua
@@ -43,7 +43,7 @@ function scene:show(event)
 
   if (phase == "will") then
     -- Show the result of the pitch
-    local pitcherRoll, batterRoll = batterManager:getResolverManager():getLastRolls()
+    local pitcherRoll, batterRoll = batterManager:getDataStore():getLastRolls()
     -- Add result
     viewManager:addComponent(
       SCENE_NAME,
@@ -53,7 +53,7 @@ function scene:show(event)
           display.newText(
           sceneGroup,
           "Result: " ..
-            batterManager:getResolverManager():getPitchResultState() ..
+            batterManager:getDataStore():getPitchResultState() ..
               " (pitcher: " .. pitcherRoll .. ", batter: " .. batterRoll .. ")",
           400,
           80,
@@ -71,7 +71,7 @@ function scene:show(event)
       SCENE_NAME,
       "TEXT_BATTER_COUNT",
       (function()
-        local balls, strikes = batterManager:getResolverManager():getCount()
+        local balls, strikes = batterManager:getDataStore():getCount()
         local resultText =
           display.newText(sceneGroup, "Count: " .. ": " .. balls .. " - " .. strikes, 400, 80, native.systemFont, 24)
         resultText.x = display.contentCenterX

--- a/scenes/game/batter-strike-zone-creation-scene.lua
+++ b/scenes/game/batter-strike-zone-creation-scene.lua
@@ -384,7 +384,7 @@ function renderSelectedCard(selectedCardID, previousCardID)
 end
 
 function renderCurrentBatter()
-  local batter = batterManager:getResolverManager():getBatter()
+  local batter = batterManager:getDataStore():getBatter()
   local currentBatterView =
     viewManager:addComponent(
     SCENE_NAME,

--- a/scenes/game/batter-swing-selection-scene.lua
+++ b/scenes/game/batter-swing-selection-scene.lua
@@ -156,7 +156,7 @@ function renderConfirmButton()
 end
 
 function renderPitchGuessSelection()
-  local pitches = batterManager:getResolverManager():getPitcher():getPitches()
+  local pitches = batterManager:getDataStore():getPitcher():getPitches()
   for i, pitch in ipairs(pitches) do
     viewManager:addComponent(
       SCENE_NAME,
@@ -235,7 +235,7 @@ function renderZoneGuessSelection()
 end
 
 function renderMatchup()
-  local batter = batterManager:getResolverManager():getBatter()
+  local batter = batterManager:getDataStore():getBatter()
   viewManager:addComponent(
     SCENE_NAME,
     "CARD_ACTIVE_BATTER",
@@ -256,7 +256,7 @@ function renderMatchup()
     end)()
   )
 
-  local pitcher = batterManager:getResolverManager():getPitcher()
+  local pitcher = batterManager:getDataStore():getPitcher()
   viewManager:addComponent(
     SCENE_NAME,
     "CARD_ACTIVE_PITCHER",
@@ -277,7 +277,7 @@ function renderMatchup()
     end)()
   )
 
-  local balls, strikes = batterManager:getResolverManager():getCount()
+  local balls, strikes = batterManager:getDataStore():getCount()
   viewManager:addComponent(
     SCENE_NAME,
     "SWING_SELECTION_COUNT",

--- a/scenes/game/services/socket-manager.lua
+++ b/scenes/game/services/socket-manager.lua
@@ -1,0 +1,97 @@
+--------------------------------------------------------------------
+-- SocketManager listens to responses from the provided websocket server
+-- and triggers actions based upon incoming responses
+--------------------------------------------------------------------
+local SolarWebSockets = require("plugin.solarwebsockets")
+local json = require("json")
+
+local SocketManager = {}
+
+-- Instantiate SocketManager (constructor)
+function SocketManager:new(options)
+  local dataStore = options.dataStore
+
+  local socketManager = {
+    dataStore = dataStore
+  }
+
+  setmetatable(socketManager, self)
+  self.__index = self
+
+  return socketManager
+end
+
+-- Establish connection
+function SocketManager:connect(socketConnectionURL)
+  -- Initialize websocket listeners
+  SolarWebSockets.init(
+    function(event)
+      self:_socketListener(event)
+    end
+  )
+
+  SolarWebSockets.connect(socketConnectionURL)
+end
+
+-- Terminate connection
+function SocketManager:disconnect()
+  SolarWebSockets.disconnect()
+end
+
+-- Send a message up to the server
+function SocketManager:sendMessage(message)
+  print("sending message: " .. message)
+  SolarWebSockets.sendServer(message)
+end
+
+-- For websocket debugging purposes
+local message = display.newText("debug messages here", 120, 320, nil, 6)
+
+-- Helper function for listener initialization logic
+function SocketManager:_socketListener(event)
+  message.text = json.encode(event)
+  if event.isClient then
+    -- Connection events
+    if event.name == "join" then
+      print("socket connection established")
+    end
+    if event.name == "message" then
+      print("got message from server")
+      message = json.decode(event.message)
+      -- Listen to updates in the game state
+      if message.type == "game_update" then
+        for key, value in pairs(message.body) do
+          self:setData(key, value)
+        end
+      end
+    end
+    if event.name == "leave" then
+      -- not connected anymore
+      print("disconnected from socket")
+      print("error code: ", tostring(event.errorCode))
+      print("error message: ", tostring(event.errorMessage))
+    end
+  end
+end
+
+-- Take the fieldKey (key of incoming data field) and update
+-- the datastore value for the corresponding key
+function SocketManager:setData(fieldKey, value)
+  local ds = self.dataStore
+  local mappings = {
+    state = ds.setState,
+    pitchResultState = ds.setPitchResultState,
+    batter = ds.setBatter,
+    pitcher = ds.setPitcher,
+    lastRollsPitcher = ds.setLastRollsPitcher,
+    lastRollsBatter = ds.setLastRollsBatter,
+    balls = ds.setCountBalls,
+    strikes = ds.setCountStrikes,
+    availableBatters = ds.setAvailableBatters
+  }
+
+  -- Update datastore for the provided key
+  mappings[fieldKey](ds, value)
+end
+
+return SocketManager

--- a/scenes/game/services/socket-manager.lua
+++ b/scenes/game/services/socket-manager.lua
@@ -4,6 +4,7 @@
 --------------------------------------------------------------------
 local SolarWebSockets = require("plugin.solarwebsockets")
 local json = require("json")
+local composer = require("composer")
 
 local SocketManager = {}
 
@@ -54,6 +55,15 @@ function SocketManager:_socketListener(event)
     -- Connection events
     if event.name == "join" then
       print("socket connection established")
+
+      -- Reload the current scene when connected
+      local currentScene = composer.getSceneName("current")
+      composer.gotoScene(
+        currentScene,
+        {
+          params = {isSocketConnectionReady = true}
+        }
+      )
     end
     if event.name == "message" then
       print("got message from server")


### PR DESCRIPTION
Kevs changelist:
(1) Add websocket library to take in requests made by the server
(2) Refactor datastore (add setters)
(3) Add SocketManager module that can update the datastore when server requests come in.  This way whenever a response comes in, we only need to update the local clientside data store and we don't need to make any additional network requests to get information.

Right now hooked up to a test websocket server which just echos responses right back when ping it.

Demo:
Fake event which comes in and updates the pitchState (PENIS) and the balls/strikes values (1/2) when you press start game.
https://user-images.githubusercontent.com/3794516/107714656-85b96480-6c82-11eb-949a-8718091edc2e.mov

