### PR TITLE
Add pitch card to UI

### DIFF
--- a/scenes/game/batter-card-zoomed-overlay.lua
+++ b/scenes/game/batter-card-zoomed-overlay.lua
@@ -32,6 +32,7 @@ function scene:show(event)
   local parent = event.parent -- Reference to the parent scene object
 
   local card = event.params["card"]
+  local cardImageURL = event.params["cardImageURL"]
 
   if (phase == "did") then
     -- Fake tin that covers the existing screen
@@ -66,7 +67,7 @@ function scene:show(event)
         local cardButton =
           widget.newButton {
           font = "asul.ttf",
-          defaultFile = assetUtil.resolveAssetPath(card:getBattingAction():getPictureURL())
+          defaultFile = assetUtil.resolveAssetPath(cardImageURL)
         }
         cardButton.x = display.contentCenterX
         cardButton.y = display.contentCenterY

--- a/scenes/game/batter-strike-zone-creation-scene.lua
+++ b/scenes/game/batter-strike-zone-creation-scene.lua
@@ -12,6 +12,7 @@ local assetUtil = require("scenes.game.utilities.asset-util")
 local constants = require("scenes.game.utilities.constants")
 local mockData = require("scenes.game.utilities.fixtures.mock-data")
 local eventHandlers = require("scenes.game.utilities.event-handlers")
+local modals = require("scenes.game.utilities.modals")
 
 -- Scene setup
 local scene = composer.newScene()
@@ -132,18 +133,7 @@ end
 -- Handle actions for selecting a card from the hand
 function onSelectCard(event, card, scrollView)
   local holdFunction = function()
-    -- Options table for the overlay scene "pause.lua"
-    local options = {
-      isModal = true,
-      effect = "zoomInOut",
-      time = 200,
-      params = {
-        card = card
-      }
-    }
-
-    -- By some method such as a "pause" button, show the overlay
-    composer.showOverlay("scenes.game.batter-card-zoomed-overlay", options)
+    modals.showCardModal(card, card:getBattingAction():getPictureURL())
   end
 
   local tapFunction = function()

--- a/scenes/game/batter-strike-zone-creation-scene.lua
+++ b/scenes/game/batter-strike-zone-creation-scene.lua
@@ -52,7 +52,7 @@ function initializeVariables()
 
   -- Action cards to use
   -- TODO (wilbert): remove when we have real action cards
-  actionCards = mockData.batterActionCards
+  actionCards = batterManager:getDataStore():getBatterActionCards()
 
   selectCardHold = false
   batterCardZoomed = false

--- a/scenes/game/entities/pitch.lua
+++ b/scenes/game/entities/pitch.lua
@@ -9,11 +9,13 @@ function Pitch:new(options)
   local id = options.id
   local name = options.name or ""
   local abbreviation = options.abbreviation or ""
+  local iconURL = options.iconURL or ""
 
   local pitch = {
     id = id,
     name = name,
     abbreviation = abbreviation,
+    iconURL = iconURL
   }
 
   setmetatable(pitch, self)
@@ -36,6 +38,10 @@ end
 
 function Pitch:getAbbreviation()
   return self.abbreviation
+end
+
+function Pitch:getIconURL()
+  return self.iconURL
 end
 
 return Pitch

--- a/scenes/game/services/data-store.lua
+++ b/scenes/game/services/data-store.lua
@@ -24,6 +24,14 @@ function DataStore:new(options)
   local lastPitcherRoll = -1
   local lastBatterRoll = -1
   local availableBatters = options.availableBatters or mockData.battingLineup
+  -- (List) Deck containing available action cards a pitcher can use
+  local pitcherActionCards = options.pitcherActionCards or mockData.pitcherActionCards
+  -- (List) Deck containing available action cards a batter can use
+  local batterActionCards = options.batterActionCards or mockData.batterActionCards
+  -- Map containing key of pitchID and value of the action card ID the pitcher has assigned
+  local inPlayPitcherActionCardsMap = options.inPlayPitcherActionCardsMap or mockData.inPlayPitcherActionCardsMap
+  -- Map containing key of zone and value of the action card ID the batter has assigned
+  local inPlayBatterActionCardsMap = options.inPlayBatterActionCardsMap or mockData.inPlayBatterActionCardsMap
 
   local dataStore = {
     state = state,
@@ -37,7 +45,11 @@ function DataStore:new(options)
     batterGuessedPitch = batterGuessedPitch,
     lastPitcherRoll = lastPitcherRoll,
     lastBatterRoll = lastBatterRoll,
-    availableBatters = availableBatters
+    availableBatters = availableBatters,
+    pitcherActionCards = pitcherActionCards,
+    batterActionCards = batterActionCards,
+    inPlayPitcherActionCardsMap = inPlayPitcherActionCardsMap,
+    inPlayBatterActionCardsMap = inPlayBatterActionCardsMap
   }
 
   setmetatable(dataStore, self)
@@ -227,6 +239,38 @@ end
 
 function DataStore:setAvailableBatters(availableBatters)
   self.availableBatters = availableBatters
+end
+
+function DataStore:getBatterActionCards()
+  return self.batterActionCards
+end
+
+function DataStore:setBatterActionCards(batterActionCards)
+  self.batterActionCards = batterActionCards
+end
+
+function DataStore:getPitcherActionCards()
+  return self.pitcherActionCards
+end
+
+function DataStore:setPitcherActionCards(pitcherActionCards)
+  self.pitcherActionCards = pitcherActionCards
+end
+
+function DataStore:getInPlayBatterActionCardsMap()
+  return self.inPlayBatterActionCardsMap
+end
+
+function DataStore:setInPlayBatterActionCardsMap(inPlayBatterActionCardsMap)
+  self.inPlayBatterActionCardsMap = inPlayBatterActionCardsMap
+end
+
+function DataStore:getInPlayPitcherActionCardsMap()
+  return self.inPlayPitcherActionCardsMap
+end
+
+function DataStore:setInPlayPitcherActionCardsMap(inPlayPitcherActionCardsMap)
+  self.inPlayPitcherActionCardsMap = inPlayPitcherActionCardsMap
 end
 
 return DataStore

--- a/scenes/game/services/socket-manager.lua
+++ b/scenes/game/services/socket-manager.lua
@@ -65,6 +65,7 @@ function SocketManager:_socketListener(event)
         }
       )
     end
+
     if event.name == "message" then
       print("got message from server")
       message = json.decode(event.message)
@@ -75,6 +76,7 @@ function SocketManager:_socketListener(event)
         end
       end
     end
+
     if event.name == "leave" then
       -- not connected anymore
       print("disconnected from socket")

--- a/scenes/game/utilities/fixtures/mock-data.lua
+++ b/scenes/game/utilities/fixtures/mock-data.lua
@@ -14,9 +14,13 @@ local pitchingStaff = {
       positions = {"p", "ss"},
       skill = skill:new({floor = 0, ceiling = 100}),
       pitches = {
-        pitch:new({id = 1, name = "FASTBALL", abbreviation = "FB"}),
-        pitch:new({id = 2, name = "CHANGEUP", abbreviation = "CH"}),
-        pitch:new({id = 3, name = "CURVEBALL", abbreviation = "CB"})
+        [1] = pitch:new({id = 1, name = "FASTBALL", abbreviation = "FB"}),
+        [2] = pitch:new({id = 2, name = "CHANGEUP", abbreviation = "CH"}),
+        [3] = pitch:new({id = 3, name = "CURVEBALL", abbreviation = "CB"}),
+        [4] = pitch:new({id = 4, name = "SLIDER", abbreviation = "SL"}),
+        [5] = pitch:new({id = 5, name = "KNUCKLEBALL", abbreviation = "KN"}),
+        [6] = pitch:new({id = 6, name = "SCREWBALL", abbreviation = "SB"}),
+        [7] = pitch:new({id = 7, name = "SPLITTER", abbreviation = "SP"})
       }
     }
   )
@@ -146,8 +150,84 @@ local batterActionCards = {
   )
 }
 
+local pitcherActionCards = {
+  [1] = actionCard:new(
+    {
+      id = "1",
+      pitchingAction = action:new(
+        {
+          id = "7",
+          name = "Herpes",
+          description = "Infects herpes and makes your pitch break 40% more.",
+          pictureURL = "action_card_sample_2.png"
+        }
+      )
+    }
+  ),
+  [2] = actionCard:new(
+    {
+      id = "2",
+      pitchingAction = action:new(
+        {
+          id = "7",
+          name = "Gonnorhea",
+          description = "Infects gonorrhea and slows your fastball down 90%",
+          pictureURL = "action_card_sample.png"
+        }
+      )
+    }
+  ),
+  [3] = actionCard:new(
+    {
+      id = "3",
+      pitchingAction = action:new(
+        {
+          id = "8",
+          name = "Clamydia",
+          description = "Infects clamydia and speeds your pitch up",
+          pictureURL = "action_card_sample.png"
+        }
+      )
+    }
+  ),
+  [4] = actionCard:new(
+    {
+      id = "4",
+      pitchingAction = action:new(
+        {
+          id = "9",
+          name = "Syphillis",
+          description = "Infects syphillis and bumps your pitch ceiling up by 69%",
+          pictureURL = "action_card_sample_2.png"
+        }
+      )
+    }
+  ),
+  [5] = actionCard:new(
+    {
+      id = "5",
+      pitchingAction = action:new(
+        {
+          id = "10",
+          name = "Hepatitis",
+          description = "Infects hepatitis and drops your pitch speed up by 2%",
+          pictureURL = "action_card_sample.png"
+        }
+      )
+    }
+  )
+}
+
+local inPlayPitcherActionCardsMap = {
+  [1] = 1,
+  [3] = 4,
+  [4] = 5
+}
+
 return {
   pitchingStaff = pitchingStaff,
   battingLineup = battingLineup,
-  batterActionCards = batterActionCards
+  batterActionCards = batterActionCards,
+  pitcherActionCards = pitcherActionCards,
+  inPlayPitcherActionCardsMap = inPlayPitcherActionCardsMap
 }

--- a/scenes/game/utilities/modals.lua
+++ b/scenes/game/utilities/modals.lua
@@ -1,0 +1,21 @@
+local composer = require("composer")
+
+local function showCardModal(card, cardImageURL)
+  -- Options table for the overlay scene "pause.lua"
+  local options = {
+    isModal = true,
+    effect = "zoomInOut",
+    time = 200,
+    params = {
+      card = card,
+      cardImageURL = cardImageURL
+    }
+  }
+
+  -- Show the overlay for a given card
+  composer.showOverlay("scenes.game.batter-card-zoomed-overlay", options)
+end
+
+return {
+  showCardModal = showCardModal
+}


### PR DESCRIPTION
Added:
(1) Show mock cards for pitch ability for a given pitcher
(2) Zoom in overlay to pitch action cards on user hold action
(3) Highlight pitch action card when it's been selected
(4) [eng cleanup] Common shared modals for pitch cards that can be more easily re-used across different scenes

https://user-images.githubusercontent.com/3794516/107842447-0c03a280-6d78-11eb-961e-c81a2e3a0292.mov

https://user-images.githubusercontent.com/3794516/107843542-d2836500-6d80-11eb-9626-646edfc1c453.mov




